### PR TITLE
chore: Mixpanel 토큰 환경변수 주입 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,7 @@ jobs:
             "INTERNAL_AUTH_SECRET=${{ secrets.INTERNAL_AUTH_SECRET }}"
             "LOGIN_SECRET=${{ secrets.LOGIN_SECRET }}"
             "GITANIMALS_ADMIN_TOKEN=${{ secrets.GITANIMALS_ADMIN_TOKEN }}"
+            "MIXPANEL_PROJECT_TOKEN=${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
 
       - name: build and push filebeat
         uses: docker/build-push-action@v4

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -24,6 +24,7 @@ ARG RELAY_APPROVE_TOKEN
 ARG INTERNAL_AUTH_SECRET
 ARG LOGIN_SECRET
 ARG GITANIMALS_ADMIN_TOKEN
+ARG MIXPANEL_PROJECT_TOKEN
 
 ARG JAR_FILE=./*.jar
 COPY ${JAR_FILE} gitanimals-api.jar
@@ -51,7 +52,8 @@ ENV db_url=${DB_URL} \
   relay_approve_token=${RELAY_APPROVE_TOKEN} \
   internal_auth_secret=${INTERNAL_AUTH_SECRET} \
   login_secret=${LOGIN_SECRET} \
-  gitanimals_admin_token=${GITANIMALS_ADMIN_TOKEN}
+  gitanimals_admin_token=${GITANIMALS_ADMIN_TOKEN} \
+  mixpanel_project_token=${MIXPANEL_PROJECT_TOKEN}
 
 ENTRYPOINT java -Djava.net.preferIPv4Stack=true -jar gitanimals-api.jar \
   --spring.datasource.url=${db_url} \


### PR DESCRIPTION
## 개요

#216 머지로 도입된 `MIXPANEL_PROJECT_TOKEN` 환경변수를 배포 파이프라인에 주입하도록 설정한다.

`application.properties`의 `mixpanel.project.token=\${MIXPANEL_PROJECT_TOKEN:}` 가 OS 환경변수에서 토큰을 읽어 `MixpanelConfiguration` 빈 생성에 사용된다. 토큰이 비어있으면 `NoOpEventLogger` 로 자동 fallback 되므로 Secret 등록 전에도 빌드/배포는 정상 동작한다.

## 변경 사항

- `deploy/api/Dockerfile`
  - `ARG MIXPANEL_PROJECT_TOKEN` 선언 추가
  - `ENV` 블록에 `mixpanel_project_token=\${MIXPANEL_PROJECT_TOKEN}` 매핑 추가
- `.github/workflows/deploy.yml`
  - `build-args` 에 `MIXPANEL_PROJECT_TOKEN=\${{ secrets.MIXPANEL_PROJECT_TOKEN }}` 추가

## 후속 작업 (수동)

- [ ] GitHub repository Secret 으로 `MIXPANEL_PROJECT_TOKEN` 등록 (값: PR #216 본문 참조)

## 참고

- Mixpanel Java SDK 는 기본 이벤트 트래킹에 프로젝트 토큰 1개만 필요 (API secret / 서비스 계정 / 리전 설정 불필요).
- `MixpanelEventLogger` 는 `MixpanelAPI()` 와 `MessageBuilder(token)` 만 사용하여 동일하게 확인됨.